### PR TITLE
Harmonise behaviour when encoding `NothingEarlier` with `Never`'s conformance to `Codable`

### DIFF
--- a/Sources/VersionedCodable/NothingEarlier.swift
+++ b/Sources/VersionedCodable/NothingEarlier.swift
@@ -7,11 +7,17 @@
 
 import Foundation
 
-/// The type to set as  `PreviousVersion` for a ``VersionedCodable`` type which does **not**
-/// have any older versions.
+/// The type to indicate that a ``VersionedCodable/VersionedCodable`` does **not** have any
+/// older versions, and the decoder should stop trying to decode it.
 ///
-/// - Warning: Don't decode or encode this type. It's just here to make the compiler work. The
-///   behaviour on decoding and encoding is undefined and may result in a crash.
+/// You typically use this when creating a new ``VersionedCodable/VersionedCodable`` type, or
+/// conforming an existing type to ``VersionedCodable/VersionedCodable``.
+///
+/// - SeeAlso: ``VersionedCodable/VersionedCodable/PreviousVersion``
+/// - Important: There's no way to create an instance of ``NothingEarlier``. It's an *uninhabited type*,
+///   similar to `Never` in the standard library.
+/// - Warning: Don't decode or initialize ``NothingEarlier``. The behaviour on decoding and
+///   encoding is undefined and may result in a crash.
 public enum NothingEarlier {}
 
 extension VersionedCodable where PreviousVersion == NothingEarlier {
@@ -30,16 +36,19 @@ extension NothingEarlier: VersionedCodable {
     public static let version: Int? = nil
     
     
-    /// - Warning: Do not invoke this initializer. The behaviour on initialization is undefined: in future it
-    ///   may result in an unrecoverable fatal error or assertion failure.
+    /// - Warning: Do not try to decode ``NothingEarlier``. The behvaiour if you do so is
+    ///   undefined. In future it may result in an unrecoverable fatal error or assertion failure.
     public init(from decoder: Decoder) throws {
-        throw VersionedDecodingError.unsupportedVersion(tried: Self.self)
+        let context = DecodingError.Context(
+               codingPath: decoder.codingPath,
+               debugDescription: "Unable to decode an instance of NothingEarlier."
+        )
+        throw DecodingError.typeMismatch(NothingEarlier.self, context)
     }
         
-    /// - Warning: Do not try to encode this type. The behaviour on encoding is undefined: in future it
-    ///   may result in an unrecoverable fatal error or assertion failure.
-    public func encode(to encoder: Encoder) throws {
-        throw VersionedDecodingError.unsupportedVersion(tried: Self.self)
-    }
+    /// - Note: It is impossible to encode ``NothingEarlier`` because ``NothingEarlier`` is
+    ///   an uninhabited type, similar to `Never` in the Swift standard library---so you can never have
+    ///   an instance of ``NothingEarlier`` to encode.
+    public func encode(to encoder: Encoder) throws { }
 }
 

--- a/Sources/VersionedCodable/NothingEarlier.swift
+++ b/Sources/VersionedCodable/NothingEarlier.swift
@@ -11,7 +11,15 @@ import Foundation
 /// older versions, and the decoder should stop trying to decode it.
 ///
 /// You typically use this when creating a new ``VersionedCodable/VersionedCodable`` type, or
-/// conforming an existing type to ``VersionedCodable/VersionedCodable``.
+/// conforming an existing type to ``VersionedCodable/VersionedCodable``. Set it as the
+/// ``VersionedCodable/VersionedCodable/PreviousVersion`` of any type that has no previous
+/// version.
+///
+/// ## Discussion
+/// The behaviour of ``NothingEarlier``'s ``VersionedCodable`` conformances is similar to
+/// how `Never` conforms to `Codable`, as defined in [SE-0396](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0396-never-codable.md)
+/// and implemented in Swift 5.9. But generally you don't need to care about this—because you will never
+/// try to (or be able to) encode or decode a `NothingEarlier` type.
 ///
 /// - SeeAlso: ``VersionedCodable/VersionedCodable/PreviousVersion``
 /// - Important: There's no way to create an instance of ``NothingEarlier``. It's an *uninhabited type*,

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -19,8 +19,8 @@ final class NothingEarlierConformanceConfidenceTests: XCTestCase {
     func testDecodingThrowsError() throws {
         XCTAssertThrowsError(try JSONDecoder().decode(NothingEarlier.self, from: blankData)) { error in
             switch error {
-            case VersionedDecodingError.unsupportedVersion(let currentVersion):
-                XCTAssertTrue(currentVersion == NothingEarlier.self)
+            case DecodingError.typeMismatch(let type, _):
+                XCTAssertTrue(type == NothingEarlier.self)
             default:
                 XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.unsupportedVersion(tried:)`, got: \(error)")
             }


### PR DESCRIPTION
[SE-0396](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0396-never-codable.md) conforms the type `Never` to `Codable`.

This PR conforms `NothingEarlier` to `VersionedCodable` using the same pattern---throwing a decoding error if decoding is attempted, and having no body for encoding (since it's impossible to encode an uninhabited type like `NothingEarlier`.)

A future enhancement might be to conform `Never` to `VersionedCodable` (see #12.) I had resisted doing this for a while because it would pollute the standard library, but in light of the new conformance to `Codable` I think this is an acceptable precedent.