### PR TITLE
Migrate to Swift Testing

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Select Xcode 16
+      run: sudo xcode-select -s /Applications/Xcode_16.app
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -214,5 +214,5 @@ As a full-time software engineer and architect for whom `VersionedCodable` is a 
 
 - [X] Allow different keypaths to the version field - **Implemented in version 1.1!**
 - [ ] Some kind of type solution to prevent clashes between the version field and a field in the `VersionedCodable` type at compile time. Needs more research, may not be possible with the current Swift compiler.
-- [ ] Swift 5.9 Macros support to significantly reduce boilerplate - *likely to be a separate package, probably not necessary for most adopters*
+- [ ] ~~Swift 5.9 Macros support to significantly reduce boilerplate~~ - *likely to be a separate package, probably not necessary for most adopters*
 - [ ] ~~(?) Potentially allow semantically versioned types. (This could be dangerous, though, as semantic versions have a very specific meaning—it's hard to see how you'd validate that v2.1 only adds to v2 and doesn't deprecate anything without some kind of static analysis, which is beyond the scope of `VersionedCodable`. It would also run the risk that backported releases to older versions would have no automatic migration path.)~~ Won't do because it increases the risk of diverging document versions with no guaranteed migration path when maintaining older versions of the system.

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -9,7 +9,8 @@ import XCTest
 import Testing
 @testable import VersionedCodable
 
-let blankData = "{}".data(using: .utf8)!
+let emptyJSONObject = "{}".data(using: .utf8)!
+
 
 @Suite("NothingEarlier")
 struct NothingEarlierTests {
@@ -39,29 +40,25 @@ struct NothingEarlierTests {
             #expect {
                 try JSONDecoder().decode(
                     NothingEarlier.self,
-                    from: blankData
+                    from: emptyJSONObject
                 )
             } throws: { error in
                 return isTypeMismatchVsNothingEarlier(error: error)
             }
         }
     }
-    
-    @Suite("Behaviour", .tags(.behaviour))
-    struct BehaviourTests {
-        @Test(
-            "works properly as the 'stopper' type where there are no previous versions",
-            .tags(.behaviour)
-        ) func decodingFromSlightlyEarlierType() throws {
-            #expect(throws: VersionedDecodingError.unsupportedVersion(tried: VersionedCodableWithoutOlderVersion.self)) {
-                try JSONDecoder().decode(
-                    versioned: VersionedCodableWithoutOlderVersion.self,
-                    from: blankData
-                )
-            }
+
+    @Test(
+        "works properly as the 'stopper' type where there are no previous versions",
+        .tags(.behaviour)
+    ) func decodingFromSlightlyEarlierType() throws {
+        #expect(throws: VersionedDecodingError.unsupportedVersion(tried: VersionedCodableWithoutOlderVersion.self)) {
+            try JSONDecoder().decode(
+                versioned: VersionedCodableWithoutOlderVersion.self,
+                from: emptyJSONObject
+            )
         }
     }
-
 }
 
 

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -9,21 +9,18 @@ import XCTest
 import Testing
 @testable import VersionedCodable
 
-@Suite("NothingEarlier")
-struct NothingEarlierConformanceConfidenceTests {
-    
-    let blankData = "{}".data(using: .utf8)!
-    
+let blankData = "{}".data(using: .utf8)!
+
+@Suite("NothingEarlier", .tags(.configuration))
+struct NothingEarlierConfigurationTests {
     @Test(
-        "has a version of `nil`",
-        .tags(.configuration)
+        "has a version of `nil`"
     ) func nothingEarlierVersionIsNil() throws {
         #expect(NothingEarlier.version == nil)
     }
     
     @Test(
-        "throws if you try to decode anything into it",
-        .tags(.configuration)
+        "throws if you try to decode anything into it"
     ) func decodingNothingEarlierThrowsAnError() throws {
         
         // TODO: 20/09/2024: The helper function is necessary due to some kind of issue with macro expansion. Remove this once the bug (in the compiler?) is resolved.
@@ -45,7 +42,10 @@ struct NothingEarlierConformanceConfidenceTests {
             return isTypeMismatchVsNothingEarlier(error: error)
         }
     }
-    
+}
+
+@Suite("NothingEarlier", .tags(.behaviour))
+struct NothingEarlierBehaviourTests {
     @Test(
         "works properly as the 'stopper' type where there are no previous versions",
         .tags(.behaviour)

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -6,37 +6,55 @@
 //
 
 import XCTest
-import VersionedCodable
+import Testing
+@testable import VersionedCodable
 
-final class NothingEarlierConformanceConfidenceTests: XCTestCase {
+@Suite("NothingEarlier")
+struct NothingEarlierConformanceConfidenceTests {
     
     let blankData = "{}".data(using: .utf8)!
     
-    func testNothingEarlierVersionIsNil() throws {
-        XCTAssertNil(NothingEarlier.version)
+    @Test(
+        "has a version of `nil`",
+        .tags(.configuration)
+    ) func nothingEarlierVersionIsNil() throws {
+        #expect(NothingEarlier.version == nil)
     }
     
-    func testDecodingThrowsError() throws {
-        XCTAssertThrowsError(try JSONDecoder().decode(NothingEarlier.self, from: blankData)) { error in
+    @Test(
+        "throws if you try to decode anything into it",
+        .tags(.configuration)
+    ) func decodingNothingEarlierThrowsAnError() throws {
+        
+        // TODO: 20/09/2024: The helper function is necessary due to some kind of issue with macro expansion. Remove this once the bug (in the compiler?) is resolved.
+        func isTypeMismatchVsNothingEarlier(error: Error) -> Bool {
             switch error {
             case DecodingError.typeMismatch(let type, _):
-                XCTAssertTrue(type == NothingEarlier.self)
+                return type == NothingEarlier.self
             default:
-                XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.unsupportedVersion(tried:)`, got: \(error)")
+                return false
             }
-
         }
         
+        #expect {
+            try JSONDecoder().decode(
+                NothingEarlier.self,
+                from: blankData
+            )
+        } throws: { error in
+            return isTypeMismatchVsNothingEarlier(error: error)
+        }
     }
     
-    func testDecodingFromSlightlyEarlierType() throws {
-        XCTAssertThrowsError(try JSONDecoder().decode(versioned: VersionedCodableWithoutOlderVersion.self, from: blankData)) { error in
-            switch error {
-            case VersionedDecodingError.unsupportedVersion(let currentVersion):
-                XCTAssertTrue(currentVersion == VersionedCodableWithoutOlderVersion.self)
-            default:
-                XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.unsupportedVersion(tried:)`, got: \(error)")
-            }
+    @Test(
+        "works properly as the 'stopper' type where there are no previous versions",
+        .tags(.behaviour)
+    ) func decodingFromSlightlyEarlierType() throws {
+        #expect(throws: VersionedDecodingError.unsupportedVersion(tried: VersionedCodableWithoutOlderVersion.self)) {
+            try JSONDecoder().decode(
+                versioned: VersionedCodableWithoutOlderVersion.self,
+                from: blankData
+            )
         }
     }
 }
@@ -47,4 +65,19 @@ struct VersionedCodableWithoutOlderVersion: VersionedCodable {
     typealias PreviousVersion = NothingEarlier
     
     var text: String
+}
+
+extension VersionedDecodingError: @retroactive Equatable {
+    public static func == (lhs: VersionedDecodingError, rhs: VersionedDecodingError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.unsupportedVersion(leftVersion), .unsupportedVersion(rightVersion)):
+            leftVersion == rightVersion
+        case (.fieldNoLongerValid, .fieldNoLongerValid):
+            true
+        default:
+            false
+        }
+    }
+    
+    
 }

--- a/Tests/VersionedCodableTests/Support/TestCategories.swift
+++ b/Tests/VersionedCodableTests/Support/TestCategories.swift
@@ -1,0 +1,14 @@
+//
+//  TestCategories.swift
+//  
+//
+//  Created by Jonathan Rothwell on 11/06/2024.
+//
+
+import Testing
+
+extension Tag {
+    @Tag static var configuration: Self
+    @Tag static var behaviour: Self
+    @Tag static var confidence: Self
+}

--- a/Tests/VersionedCodableTests/UnusualVersionKeyPathsTests.swift
+++ b/Tests/VersionedCodableTests/UnusualVersionKeyPathsTests.swift
@@ -10,8 +10,10 @@ import Foundation
 @testable import VersionedCodable
 
 /// Tests unusual paths to the version field in VersionedCodable.
-@Suite("Custom version KeyPaths", .tags(.behaviour)) struct UnusualVersionKeyPathsTests {
-    @Test("decodes a `_version` field at the root of the type with a simple spec") func fieldAtRootWithSimpleName() throws {
+@Suite("Custom version KeyPaths", .tags(.behaviour))
+struct UnusualVersionKeyPathsTests {
+    @Test("decodes a `_version` field at the root of the type with a simple spec")
+    func fieldAtRootWithSimpleName() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "sonnet-v1",
                                           withExtension: "json")!)
@@ -19,7 +21,8 @@ import Foundation
         #expect("William Shakespeare" == decoded.author)
     }
     
-    @Test("decodes a version field nested further inside a `metadata` key") func fieldWithMoreComplexPath() throws {
+    @Test("decodes a version field nested further inside a `metadata` key")
+    func fieldWithMoreComplexPath() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "sonnet-v2",
                                           withExtension: "json")!)

--- a/Tests/VersionedCodableTests/UnusualVersionKeyPathsTests.swift
+++ b/Tests/VersionedCodableTests/UnusualVersionKeyPathsTests.swift
@@ -5,27 +5,26 @@
 //  Created by Jonathan Rothwell on 23/01/2024.
 //
 
-import XCTest
+import Testing
+import Foundation
 @testable import VersionedCodable
 
 /// Tests unusual paths to the version field in VersionedCodable.
-final class UnusualVersionKeyPathsTests: XCTestCase {
-
-
-    func testFieldAtRootWithSimpleName() throws {
+@Suite("Custom version KeyPaths", .tags(.behaviour)) struct UnusualVersionKeyPathsTests {
+    @Test("decodes a `_version` field at the root of the type with a simple spec") func fieldAtRootWithSimpleName() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "sonnet-v1",
                                           withExtension: "json")!)
         let decoded = try JSONDecoder().decode(versioned: SonnetV1.self, from: data)
-        XCTAssertEqual("William Shakespeare", decoded.author)
+        #expect("William Shakespeare" == decoded.author)
     }
     
-    func testFieldWithMoreComplexPath() throws {
+    @Test("decodes a version field nested further inside a `metadata` key") func fieldWithMoreComplexPath() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "sonnet-v2",
                                           withExtension: "json")!)
         let decoded = try JSONDecoder().decode(versioned: SonnetV2.self, from: data)
-        XCTAssertEqual("William Shakespeare", decoded.author)
+        #expect("William Shakespeare" == decoded.author)
     }
 
 }

--- a/Tests/VersionedCodableTests/VersionedCodableJSONTests.swift
+++ b/Tests/VersionedCodableTests/VersionedCodableJSONTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Testing
+import Foundation
 @testable import VersionedCodable
 
 struct VersionedDocument: Codable {
@@ -6,9 +7,10 @@ struct VersionedDocument: Codable {
 }
 
 
-final class VersionedCodableJSONTests: XCTestCase {
-
-    func testDecodingPoemPreV1ToPoemV1() throws {
+@Suite("JSONDecoder encoding/decoding", .tags(.behaviour))
+struct VersionedCodableJSONTests {
+    @Test("decodes a grandfathered type with no version field")
+    func decodingPoemPreV1ToPoemV1() throws {
         let oldPoem = """
                       {
                         "author": "John Smith",
@@ -17,14 +19,15 @@ final class VersionedCodableJSONTests: XCTestCase {
                       """.data(using: .utf8)!
         
         
-        let migrated = try JSONDecoder().decode(
-            versioned: Poem.PoemV1.self,
-            from: oldPoem)
-        XCTAssertEqual(migrated.author, "John Smith")
-        XCTAssertEqual(migrated.poem, "Hello")
+        let migrated = try JSONDecoder()
+            .decode(versioned: Poem.PoemV1.self,
+                    from: oldPoem)
+        #expect("John Smith" == migrated.author)
+        #expect("Hello" == migrated.poem)
     }
     
-    func testDecodingPoemPreV1ToPoemV1WhereWeDiscardDueToNewMandatoryFields() throws {
+    @Test("throws when trying to decode type if some fields are now mandatory")
+    func decodingPoemPreV1ToPoemV1ThrowsDueToNewMandatoryFields() throws {
         let oldPoem = """
                       {
                         "author": "John Smith",
@@ -32,20 +35,29 @@ final class VersionedCodableJSONTests: XCTestCase {
                       }
                       """.data(using: .utf8)!
         
-        XCTAssertThrowsError(try JSONDecoder().decode(
-            versioned: Poem.PoemV1.self,
-            from: oldPoem)) { error in
-                switch error {
-                case VersionedDecodingError.fieldNoLongerValid(let context):
-                    XCTAssertEqual("poem", context.codingPath[0].stringValue)
-                    XCTAssertEqual("Poem is no longer optional", context.debugDescription)
-                default:
-                    XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.fieldNoLongerValid`, got: \(error))")
-                }
-            }
+        
+        #expect {
+            try JSONDecoder().decode(
+                versioned: Poem.PoemV1.self,
+                from: oldPoem
+            )
+        } throws: { error in
+            guard let error = error as? VersionedDecodingError,
+                  case .fieldNoLongerValid(let context) = error else {
+                      return false
+                  }
+            
+            return (
+                "poem" == context.codingPath[0].stringValue
+            ) && (
+                "Poem is no longer optional" == context.debugDescription
+            )
+            
+        }
     }
     
-    func testDecodingOlderVersionThanWeSupportExplodes() throws {
+    @Test("throws when decoding an older version than we support")
+    func throwsWhenDecodingOlderVersionThanWeSupport() throws {
         let oldPoem = """
                       {
                         "version": -1,
@@ -54,19 +66,16 @@ final class VersionedCodableJSONTests: XCTestCase {
                       }
                       """.data(using: .utf8)!
         
-        XCTAssertThrowsError(try JSONDecoder().decode(
-            versioned: Poem.PoemV1.self,
-            from: oldPoem)) { error in
-                switch error {
-                case VersionedDecodingError.unsupportedVersion(let olderVersion):
-                    XCTAssertTrue(olderVersion == Poem.PoemPreV1.self)
-                default:
-                    XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.unsupportedVersion(Poem.PoemPreV1)`, got: \(error))")
-                }
-            }
+        #expect(throws: VersionedDecodingError.unsupportedVersion(tried: Poem.PoemPreV1.self)) {
+            try JSONDecoder().decode(
+                versioned: Poem.PoemV1.self,
+                from: oldPoem
+            )
+        }
     }
     
-    func testMultiStageMigration() throws {
+    @Test("performs a multi-stage migration")
+    func multiStageMigration() throws {
         let oldPoem = """
                       {
                         "version": 1,
@@ -75,13 +84,23 @@ final class VersionedCodableJSONTests: XCTestCase {
                       }
                       """.data(using: .utf8)!
         
-        let migrated = try JSONDecoder()
-            .decode(versioned: Poem.self,
-                    from: oldPoem)
-        XCTAssertEqual(["An epicure dining at Crewe", "Found a rather large mouse in his stew", "Cried the waiter: Don\'t shout", "And wave it about", "Or the rest will be wanting one too!"], migrated.lines)
-        XCTAssertEqual("A Clever Man", migrated.author?.name)
+        let migrated = try JSONDecoder().decode(
+            versioned: Poem.self,
+            from: oldPoem)
+        
+        #expect(
+            [
+                "An epicure dining at Crewe",
+                "Found a rather large mouse in his stew",
+                "Cried the waiter: Don\'t shout",
+                "And wave it about",
+                "Or the rest will be wanting one too!"
+            ] == migrated.lines
+        )
+        #expect("A Clever Man" == migrated.author?.name)
     }
     
+    @Test("encodes the version properly")
     func testVersionEncodedCorrectly() throws {
         let oldPoem = """
                       {
@@ -94,16 +113,25 @@ final class VersionedCodableJSONTests: XCTestCase {
         let migrated = try JSONDecoder()
             .decode(versioned: Poem.self,
                     from: oldPoem)
+        
 
         let encoded = try JSONEncoder().encode(versioned: migrated)
         
         let versionedDocument = try JSONDecoder().decode(VersionedDocument.self, from: encoded)
         
-        XCTAssertEqual(4, versionedDocument.version)
+        #expect(4 == versionedDocument.version)
         
         let encodedAndDecodedDocument = try JSONDecoder().decode(Poem.self, from: encoded)
-        XCTAssertEqual(["An epicure dining at Crewe", "Found a rather large mouse in his stew", "Cried the waiter: Don\'t shout", "And wave it about", "Or the rest will be wanting one too!"], encodedAndDecodedDocument.lines)
-        XCTAssertEqual("A Clever Man", encodedAndDecodedDocument.author?.name)
+        #expect(
+            [
+                "An epicure dining at Crewe",
+                "Found a rather large mouse in his stew",
+                "Cried the waiter: Don\'t shout",
+                "And wave it about",
+                "Or the rest will be wanting one too!"
+            ] == encodedAndDecodedDocument.lines
+        )
+        #expect("A Clever Man" == encodedAndDecodedDocument.author?.name)
     }
 
 }

--- a/Tests/VersionedCodableTests/VersionedCodableJSONTests.swift
+++ b/Tests/VersionedCodableTests/VersionedCodableJSONTests.swift
@@ -7,7 +7,8 @@ struct VersionedDocument: Codable {
 }
 
 
-@Suite("JSONDecoder encoding/decoding", .tags(.behaviour))
+@Suite("JSONDecoder encoding/decoding",
+       .tags(.behaviour))
 struct VersionedCodableJSONTests {
     @Test("decodes a grandfathered type with no version field")
     func decodingPoemPreV1ToPoemV1() throws {

--- a/Tests/VersionedCodableTests/VersionedCodablePropertyListTests.swift
+++ b/Tests/VersionedCodableTests/VersionedCodablePropertyListTests.swift
@@ -5,12 +5,14 @@
 //  Created by Jonathan Rothwell on 18/04/2023.
 //
 
-import XCTest
-import VersionedCodable
+import Testing
+import Foundation
+@testable import VersionedCodable
 
-final class VersionedCodablePropertyListTests: XCTestCase {
+@Suite("Property lists", .tags(.behaviour)) struct VersionedCodablePropertyListTests {
 
-    func testEncoding() throws {
+    @Test("A Codable encodes into a property list")
+    func encoding() throws {
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
         // XML makes our life a bit easier because it's human-readable,
@@ -20,42 +22,40 @@ final class VersionedCodablePropertyListTests: XCTestCase {
             contentsOf: Bundle.module.url(forResource: "expectedEncoded",
                                           withExtension: "plist")!)
         let data = try encoder.encode(versioned: poemForEncoding)
-        XCTAssertEqual(String(data: expected, encoding: .utf8)!,
+        #expect(String(data: expected, encoding: .utf8)! ==
                        String(data: data, encoding: .utf8)!)
     }
     
-    func testDecodingCurrentVersion() throws {
+    @Test("current version decodes correctly")
+    func decodingCurrentVersion() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "expectedEncoded",
                                           withExtension: "plist")!)
         let decoded = try PropertyListDecoder()
             .decode(versioned: Poem.self, from: data)
-        XCTAssertEqual("William Topaz McGonagall", decoded.author?.name)
+        #expect("William Topaz McGonagall" == decoded.author?.name)
     }
     
-    func testDecodingOldVersion() throws {
+    @Test("older version decodes correctly")
+    func decodingOldVersion() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "expectedOlder",
                                           withExtension: "plist")!)
         let decoded = try PropertyListDecoder()
             .decode(versioned: Poem.self, from: data)
-        XCTAssertEqual("William Topaz McGonagall", decoded.author?.name)
-        XCTAssertEqual(examplePoem, decoded.lines)
+        #expect("William Topaz McGonagall" == decoded.author?.name)
+        #expect(examplePoem == decoded.lines)
     }
 
-    func testDecodingUnsupportedVersion() throws {
+    @Test("throws when decoding unsupported version")
+    func decodingUnsupportedVersion() throws {
         let data = try Data(
             contentsOf: Bundle.module.url(forResource: "expectedUnsupported",
                                           withExtension: "plist")!)
-        XCTAssertThrowsError(try PropertyListDecoder()
-            .decode(versioned: Poem.self, from: data)) { error in
-                switch error {
-                case VersionedDecodingError.unsupportedVersion(let lastTriedVersion):
-                    XCTAssertTrue(lastTriedVersion == Poem.PoemPreV1.self)
-                default:
-                    XCTFail("An error threw, but it was the wrong kind of error (expected `VersionedDecodingError.unsupportedVersion(tried:)`, got: `\(error)`)")
-                }
-            }
+        #expect(throws:
+                    VersionedDecodingError.unsupportedVersion(tried: Poem.PoemPreV1.self)) {
+            try PropertyListDecoder().decode(versioned: Poem.self, from: data)
+        }
     }
     
 


### PR DESCRIPTION
Adopts Swift Testing for all unit tests in the package, except our performance test. This fulfils #14.