### PR TITLE
Conform `Never` to `VersionedCodable`

### DIFF
--- a/Sources/VersionedCodable/Foundation Extensions/Never+VersionedCodable.swift
+++ b/Sources/VersionedCodable/Foundation Extensions/Never+VersionedCodable.swift
@@ -1,0 +1,16 @@
+//
+//  Never+VersionedCodable.swift
+//  VersionedCodable
+//
+//  Created by Jonathan Rothwell on 01/10/2024.
+//
+
+@available(swift, introduced: 5.9)
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+extension Never: VersionedCodable {
+    public typealias PreviousVersion = NothingEarlier
+
+    public static var version: Int? {
+        nil
+    }
+}

--- a/Tests/VersionedCodableTests/NeverVersionedCodableConformanceTests.swift
+++ b/Tests/VersionedCodableTests/NeverVersionedCodableConformanceTests.swift
@@ -1,0 +1,23 @@
+//
+//  NeverVersionedCodableConformanceTests.swift
+//  VersionedCodable
+//
+//  Created by Jonathan Rothwell on 01/10/2024.
+//
+
+import Foundation
+import Testing
+@testable import VersionedCodable
+
+
+@available(macOS 14.0, iOS 17.0, *)
+@Test("`Never` won't decode using the `VersionedCodable` decoding method", .tags(.configuration))
+func neverDoesntDecode() async throws {    
+    let neverJSON = Data(#"{"no": "no"}"#.utf8)
+    #expect {
+        try JSONDecoder().decode(versioned: Never.self, from: neverJSON)
+    } throws: { error in
+        isTypeMismatch(error, vs: Never.self)
+    }
+            
+}

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Jonathan Rothwell on 15/04/2023.
 //
 
-import XCTest
+import Foundation
 import Testing
 @testable import VersionedCodable
 
@@ -26,24 +26,13 @@ struct NothingEarlierTests {
         @Test(
             "throws if you try to decode anything into it"
         ) func decodingNothingEarlierThrowsAnError() throws {
-            
-            // TODO: 20/09/2024: The helper function is necessary due to some kind of issue with macro expansion. Remove this once the bug (in the compiler?) is resolved.
-            func isTypeMismatchVsNothingEarlier(error: Error) -> Bool {
-                switch error {
-                case DecodingError.typeMismatch(let type, _):
-                    return type == NothingEarlier.self
-                default:
-                    return false
-                }
-            }
-            
             #expect {
                 try JSONDecoder().decode(
                     NothingEarlier.self,
                     from: emptyJSONObject
                 )
             } throws: { error in
-                return isTypeMismatchVsNothingEarlier(error: error)
+                return isTypeMismatch(error, vs: NothingEarlier.self)
             }
         }
     }

--- a/Tests/VersionedCodableTests/Support/IsTypeMismatchVs.swift
+++ b/Tests/VersionedCodableTests/Support/IsTypeMismatchVs.swift
@@ -1,0 +1,16 @@
+//
+//  IsTypeMismatchVs.swift
+//  VersionedCodable
+//
+//  Created by Jonathan Rothwell on 01/10/2024.
+//
+
+func isTypeMismatch<T>(_ error: Error, vs otherType: T.Type) -> Bool {
+    switch error {
+    case DecodingError.typeMismatch(let thisType, _):
+        return thisType == T.self
+    default:
+        return false
+    }
+
+}


### PR DESCRIPTION
This brings us in line with `Never` also conforming to `Codable`.

Note that this is only available in Swift 5.9 and above and the associated OS releases (iOS 17, macOS 14, etc.) This is because `Never` was only conformed to `Codable` as part of [SE-0396](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0396-never-codable.md).

There is no custom behaviour specified here: we are relying on `Never` generally failing when we attempt to encode/decode it.