### PR TITLE
Swift 6 strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,10 @@
 // swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "VersionedCodable",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "VersionedCodable",
             targets: ["VersionedCodable"]),
@@ -15,8 +13,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "VersionedCodable",
             dependencies: [],

--- a/Package@swift-5.7.1.swift
+++ b/Package@swift-5.7.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.7.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,8 +22,7 @@ let package = Package(
             dependencies: [],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")
-            ]
-        ),
+            ]),
         .testTarget(
             name: "VersionedCodableTests",
             dependencies: ["VersionedCodable"],
@@ -33,7 +32,6 @@ let package = Package(
                 .copy("Support/expectedUnsupported.plist"),
                 .copy("Support/UnusualKeyPaths/sonnet-v1.json"),
                 .copy("Support/UnusualKeyPaths/sonnet-v2.json")
-            ]
-        ),
+            ]),
     ]
 )

--- a/Package@swift-5.7.1.swift
+++ b/Package@swift-5.7.1.swift
@@ -1,12 +1,10 @@
 // swift-tools-version: 5.7.1
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "VersionedCodable",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "VersionedCodable",
             targets: ["VersionedCodable"]),
@@ -15,8 +13,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "VersionedCodable",
             dependencies: [],

--- a/Sources/VersionedCodable/VersionPathSpec.swift
+++ b/Sources/VersionedCodable/VersionPathSpec.swift
@@ -10,7 +10,17 @@ import Foundation
 /// Describes how to decode or encode the version of a ``VersionedCodable`` type.
 public protocol VersionPathSpec: Codable {
     /// The key path to the version of this type. Used to find the version key during decoding.
-    static var keyPathToVersion: KeyPath<Self, Int?> { get }
+    ///
+    /// Generally you declare this as a `static let`, for instance, like this:
+    ///
+    /// ```swift
+    /// static let keyPathToVersion = \Self.metadata.version
+    /// ```
+    /// - Important: It is your responsibility to make sure that `keyPathToVersion` is immutable
+    ///   and does not change. The behaviour if it does change mid-execution is undefined. It's not a good
+    ///   idea to declare `keyPathToVersion` as a computed property, or a `var` which the caller
+    ///   can then change. Nor should you capture the `KeyPath` and mutate it elsewhere.
+    nonisolated(unsafe) static var keyPathToVersion: KeyPath<Self, Int?> { get }
     
     /// Initializes the type with the provided version.
     /// - Parameter version: The version of the document being encoded.

--- a/Sources/VersionedCodable/VersionPathSpec.swift
+++ b/Sources/VersionedCodable/VersionPathSpec.swift
@@ -30,12 +30,12 @@ public protocol VersionPathSpec: Codable {
 
 /// Describes how to encode and decode the version of a ``VersionedCodable`` type where the version is encoded at the root of the type in a field called `version`.
 public struct VersionKeyAtRootVersionPathSpec: Codable, VersionPathSpec {
-    public static let keyPathToVersion: KeyPath<VersionKeyAtRootVersionPathSpec, Int?> = \Self.version
+    public static let keyPathToVersion: KeyPath<Self, Int?> = \Self.version
     public init(withVersion version: Int? = nil) {
         self.version = version
     }
     
-    var version: Int?
+    let version: Int?
 }
 
 

--- a/Sources/VersionedCodable/VersionedCodable.swift
+++ b/Sources/VersionedCodable/VersionedCodable.swift
@@ -24,8 +24,17 @@ public protocol VersionedCodable: Codable {
     /// The current version of this type. This is what is encoded into the `version` key on this type
     /// when it is encoded.
     ///
+    /// Generally you declare it as a `static let`, for instance:
+    ///
+    /// ```swift
+    /// static let version = 3
+    /// ```
+    ///
     /// - Note: It's possible for this to be `nil`, to account for versions of the type that were created and
     /// encoded/persisted to disk before you adopted ``VersionedCodable``.
+    /// - Important: It is your responsibility to make sure that `version` is immutable and does not
+    ///   change. The behaviour if it does change mid-execution is undefined. It's not a good idea to
+    ///   declare `version` as a computed property, or a `var` which the caller can then change.
     static var version: Int? { get }
     
     /// The next oldest version of this type, or ``NothingEarlier`` if this *is* the oldest version.

--- a/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
+++ b/Tests/VersionedCodableTests/NothingEarlierConformanceConfidenceTests.swift
@@ -59,7 +59,7 @@ struct VersionedCodableWithoutOlderVersion: VersionedCodable {
     var text: String
 }
 
-extension VersionedDecodingError: @retroactive Equatable {
+extension VersionedDecodingError: Equatable {
     public static func == (lhs: VersionedDecodingError, rhs: VersionedDecodingError) -> Bool {
         switch (lhs, rhs) {
         case let (.unsupportedVersion(leftVersion), .unsupportedVersion(rightVersion)):


### PR DESCRIPTION

* Adds explicit support for Swift 6 language mode and strict concurrency (#15)
* Retains support for Swift 5.7.1 or above with an additional targeted `Package.swift`.
* Marks `KeyPathVersionSpec.keyPathToVersion` as `nonisolated(unsafe)` and adds documentation indicating that it is the caller's responsibility to make sure it does not change.